### PR TITLE
Change isEditable status false when table is clicked.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
 		<h2>検索用テーブル</h2>
 		<vue-good-table
 			@on-selected-rows-change="selectionChanged"
+			@on-row-click="onRowClick"
 			ref="my-table"
 			:select-options="{
 				enabled: true,
@@ -232,6 +233,9 @@ export default {
 		},
 		toggleAccordion() {
 			this.isOpened = !this.isOpened;
+		},
+		onRowClick() {
+			this.isEditable = false;
 		}
 	}
 };


### PR DESCRIPTION
close #60 
本当はダブルクリックしたときに編集可能になるセルを絞って、そこにカーソルが行くようにしたいが、
今の編集可能にするやり方はvue-good-tableの機能を使っているわけではないので、難しそう。
とりあえず編集可能な領域外をクリックしたときに編集可能状態から通常の状態にできるようになったので、
当面はこれでよしとする。
vue-good-tableに@on-cell-dblclick機能が実装されたら、やりたかったことはできそうだが。