### PR TITLE
fixbug

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,8 @@
 				<button @click="removeItems()">Delete</button>
 			</div>
 			<template slot="table-row" slot-scope="props">
-				<span v-if="isEditable">
+				<!-- dblclickをclickにすると、編集可能領域にカーソルを持って行った瞬間通常状態に戻ってしまう -->
+				<span v-if="isEditable" v-on:dblclick="isEditable = false">
 					<div>
 						<input
 							type="text"
@@ -176,6 +177,7 @@ export default {
 		updateItem(editItem) {
 			this.items.splice(editItem.row.originalIndex, 1, editItem.formattedRow);
 			this.saveItems();
+			// 編集後、領域外をクリックすると通常状態に戻る
 			this.isEditable = false;
 		},
 		initializeItems() {


### PR DESCRIPTION
close #65 

編集可能領域にカーソルが当たってない時はダブルクリック、
編集可能領域にカーソルが当たっている時はクリックで通常状態に戻る。
本当は編集可能領域にカーソルが当たってない時もクリックで通常状態に戻したいが、
それやろうとすると編集可能領域にカーソル当てた瞬間に通常状態に戻ってしまい、
回避方法がわからないから、一旦これでいく。